### PR TITLE
Added onClickClose Handler for Notification Component

### DIFF
--- a/packages/vuesax/src/functions/vsNotification/Base/index.ts
+++ b/packages/vuesax/src/functions/vsNotification/Base/index.ts
@@ -11,6 +11,7 @@ interface NotificationParams {
   icon?: string
   duration?: number | string
   onClick?: any
+  onClickClose?: any
   buttonClose?: boolean
   flat?: boolean
   onDestroy?: any
@@ -59,6 +60,7 @@ const notification = (params: NotificationParams = {}) => {
   instance.$data.border = params.border
   instance.$data.icon = params.icon
   instance.$data.onClick = params.onClick
+  instance.$data.onClickClose = params.onClickClose
   instance.$data.flat = params.flat
   instance.$data.onDestroy = params.onDestroy
   instance.$data.sticky = params.sticky

--- a/packages/vuesax/src/functions/vsNotification/Base/vsNotification.ts
+++ b/packages/vuesax/src/functions/vsNotification/Base/vsNotification.ts
@@ -21,6 +21,8 @@ export default class VsNotification extends Vue {
   border: string | null = null
 
   icon: string | null = null
+  
+  onClickClose: any = null
 
   onClick: any = null
 
@@ -60,6 +62,7 @@ export default class VsNotification extends Vue {
 
   handleClickClose() {
     this.isVisible = false
+    this.onClickClose();
   }
 
   beforeEnter(el: any) {

--- a/packages/vuesax/src/functions/vsNotification/Base/vsNotification.ts
+++ b/packages/vuesax/src/functions/vsNotification/Base/vsNotification.ts
@@ -62,7 +62,6 @@ export default class VsNotification extends Vue {
 
   handleClickClose() {
     this.isVisible = false
-    this.onClickClose();
   }
 
   beforeEnter(el: any) {
@@ -200,6 +199,7 @@ export default class VsNotification extends Vue {
             { 'vs-notification--border': this.border },
             { 'vs-notification--icon': this.icon },
             { 'vs-notification--onClick': this.onClick },
+            { 'vs-notification--onClickClose': this.onClickClose },
             { 'vs-notification--flat': this.flat },
             { 'vs-notification--sticky': this.sticky },
             { 'vs-notification--square': this.square },
@@ -217,6 +217,9 @@ export default class VsNotification extends Vue {
               }
               if (this.clickClose) {
                 this.close()
+                if (this.onClickClose) {
+                  this.onClickClose()
+                }
               }
             }
           }


### PR DESCRIPTION
This callback is fired when a user clicks `cross` / `close` button of our notification.

It is necessary in cases like cookie consent notification, where we would be tracking if the user clicked `accept` button or just closed our notification via the `close` button on the top right.