### PR TITLE
Do not insert if tooltip is not a valid HTMLElement

### DIFF
--- a/packages/vuesax/src/components/vsTooltip/Base/vsTooltip.ts
+++ b/packages/vuesax/src/components/vsTooltip/Base/vsTooltip.ts
@@ -40,6 +40,7 @@ export default class VsTooltip extends VsComponent {
 
   insertTooltip() {
     const tooltip = this.$refs.tooltip as HTMLElement
+    if (!tooltip) { return }
     insertBody(tooltip, document.body)
 
     let position = 'top'


### PR DESCRIPTION
Pretty similar to line 88.
Fixes flicker tooltip error (see below)
Also Fixes #128

### Flicker tooltip error:
Encountered with this error randomly so many times. Couldn't figure out what was wrong at first.

**What steps will reproduce the issue?**
I moved my cursor around tooltip object like crazy and managed to overlap two events.

**What causes this to happen?**
Tooltip removing is triggered instantly, yet insertTooltip is waiting for this.$nextTick.
If tooltip is removed before insertTooltip, it emits an error.

**How to fix?**
Just look if tooltip is defined or not.