### PR TITLE
add vsloading progress translate animation

### DIFF
--- a/packages/vuesax/src/functions/vsLoading/Base/index.ts
+++ b/packages/vuesax/src/functions/vsLoading/Base/index.ts
@@ -27,7 +27,7 @@ loadingConstructor.prototype.close = function() {
   setTimeout(() => {
     this.$destroy()
     this.$el.parentNode.removeChild(this.$el)
-  }, 250)
+  }, this.progressTransitionSpeed + 250)
 }
 
 loadingConstructor.prototype.changePercent = function(val: string) {

--- a/packages/vuesax/src/functions/vsLoading/Base/index.ts
+++ b/packages/vuesax/src/functions/vsLoading/Base/index.ts
@@ -11,6 +11,7 @@ interface LoadingParams {
   opacity?: string
   percent?: string
   progress?: string
+  progressTransitionSpeed?: number
   target?: any
   scale?: string
 }
@@ -19,8 +20,10 @@ const loadingConstructor = Vue.extend(component)
 
 // tslint:disable-next-line:only-arrow-functions
 loadingConstructor.prototype.close = function() {
-  this.isVisible = false
-  document.body.style.overflowY = 'auto'
+  setTimeout(() => {
+    this.isVisible = false
+    document.body.style.overflowY = 'auto'
+  }, this.progressTransitionSpeed)
   setTimeout(() => {
     this.$destroy()
     this.$el.parentNode.removeChild(this.$el)
@@ -65,6 +68,7 @@ const loading = (params: LoadingParams = {}) => {
   instance.$data.percent = params.percent
   instance.$data.type = params.type
   instance.$data.progress = params.progress
+  instance.$data.progressTransitionSpeed = params.progressTransitionSpeed
   instance.$data.scale = params.scale
 
   params.target.appendChild(instance.$mount().$el)

--- a/packages/vuesax/src/functions/vsLoading/Base/style.sass
+++ b/packages/vuesax/src/functions/vsLoading/Base/style.sass
@@ -64,6 +64,7 @@
     background: -color('color')
     height: 100%
     width: 100%
+    transform: translateX(-100%)
     position: relative
     border-radius: 0px 10px 10px 0px
 

--- a/packages/vuesax/src/functions/vsLoading/Base/style.sass
+++ b/packages/vuesax/src/functions/vsLoading/Base/style.sass
@@ -59,9 +59,11 @@
   left: 0px
   height: 4px
   background: -color('color', .2)
+  overflow: hidden
   &__bar
     background: -color('color')
     height: 100%
+    width: 100%
     position: relative
     border-radius: 0px 10px 10px 0px
 

--- a/packages/vuesax/src/functions/vsLoading/Base/vsLoading.ts
+++ b/packages/vuesax/src/functions/vsLoading/Base/vsLoading.ts
@@ -18,6 +18,8 @@ export default class VsLoading extends Vue {
 
   progress: string | null = null
 
+  progressTransitionSpeed: number = 0
+
   scale: string | null = null
 
   target: any = null
@@ -75,7 +77,8 @@ export default class VsLoading extends Vue {
       h('div', {
         staticClass: 'vs-loading__progress__bar',
         style: {
-          width: `${this.progress}%`
+          transform: `translateX(${this.progress}%)`,
+          transition: `transform ${this.progressTransitionSpeed}ms ease`
         }
       })
     ])

--- a/packages/vuesax/src/functions/vsLoading/Base/vsLoading.ts
+++ b/packages/vuesax/src/functions/vsLoading/Base/vsLoading.ts
@@ -77,7 +77,7 @@ export default class VsLoading extends Vue {
       h('div', {
         staticClass: 'vs-loading__progress__bar',
         style: {
-          transform: `translateX(${this.progress}%)`,
+          transform: `translateX(calc(-100% + ${this.progress}%))`,
           transition: `transform ${this.progressTransitionSpeed}ms ease`
         }
       })


### PR DESCRIPTION
- Add "progressTransitionSpeed" parameter to enable transition, value is a number in ms :
ex. `this.$vs.loading({text: 'Loading...', type: 'scale', progress: 0.01, progressTransitionSpeed: 1000});`
- Changed the "width" value update from this.progress to a "translateX" value update for better performance in case of animation (width property needs repaint)

![test](https://user-images.githubusercontent.com/49032117/110206995-64aef280-7e81-11eb-9337-3c0782f70978.gif)
