### PR TITLE
don't commit webstorm '.idea' file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+#idea laoding project
+.idea


### PR DESCRIPTION
Use webstorm open project, but my git tell me that you should commit the '.idea' file content,. This is a pain when I submit code with webstorm. I hope this will make it easier for more webstorm users to contribute code. 